### PR TITLE
ci: repoint install-spatial-deps to @main

### DIFF
--- a/.github/workflows/render-module-rmd.yaml
+++ b/.github/workflows/render-module-rmd.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      - uses: PredictiveEcology/actions/install-spatial-deps@main
 
       - name: Install other dependencies
         run: |


### PR DESCRIPTION
Every published tag of `install-spatial-deps` — v0.1 through v0.5, including the newest — still runs:

```
add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
```

That PPA installs **libgdal37**. These workflows install R packages through `Require::setLinuxBinaryRepo()`, which fetches Posit's **noble** binaries — built against the Ubuntu-default **libgdal34**. The mismatch only surfaces at lazy-load, as `libgdal.so.34: cannot open shared object file`, and takes the whole job with it.

Only `@main` dropped the PPA (PredictiveEcology/actions#25). Tags do not move, so pinning to one — even the newest — keeps the hazard.

### Why this path in particular

`Require` sets `PKG_SYSREQS=false` and `PKG_SYSREQS_SUDO=false` at load, deliberately: CRAN treats a sudo attempt from package code as an attempt to hijack the machine. So on `install-SpaDES` / `install-Rmd-pkgs` workflows, pak never installs system dependencies and `install-spatial-deps` is the *only* thing providing GDAL. That is why this action stays — and why the pin has to be correct.

Changed **1** reference(s) in:
```
.github/workflows/render-module-rmd.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)